### PR TITLE
Allow multiple waypoints

### DIFF
--- a/mapbox/src/main/java/com/graphhopper/navigation/mapbox/MapboxResponseConverter.java
+++ b/mapbox/src/main/java/com/graphhopper/navigation/mapbox/MapboxResponseConverter.java
@@ -50,31 +50,35 @@ public class MapboxResponseConverter {
             PathWrapper path = paths.get(i);
             ObjectNode pathJson = routesJson.addObject();
 
+            InstructionList instructions = path.getInstructions();
+
             pathJson.put("geometry", WebHelper.encodePolyline(path.getPoints(), false, 1e6));
             ArrayNode legsJson = pathJson.putArray("legs");
 
-            //TODO: support multiple legs (=> multiple waypoints...)
             ObjectNode legJson = legsJson.addObject();
-
-            // TODO: Improve path descriptions, so that every path has a description, not just alternative routes
-            String summary;
-            if (!path.getDescription().isEmpty())
-                summary = String.join(",", path.getDescription());
-            else
-                summary = "GraphHopper Route " + i;
-            legJson.put("summary", summary);
-
-            // Copied from below
-            legJson.put("weight", Helper.round(path.getRouteWeight(), 1));
-            legJson.put("duration", convertToSeconds(path.getTime()));
-            legJson.put("distance", Helper.round(path.getDistance(), 1));
-
             ArrayNode steps = legJson.putArray("steps");
-            InstructionList instructions = path.getInstructions();
+
+            long time = 0;
+            double distance = 0;
+            boolean isFirstInstructionOfLeg = true;
 
             for (int j = 0; j < instructions.size(); j++) {
                 ObjectNode instructionJson = steps.addObject();
-                putInstruction(instructions, j, locale, translationMap, instructionJson);
+                putInstruction(instructions, j, locale, translationMap, instructionJson, isFirstInstructionOfLeg);
+                Instruction instruction = instructions.get(j);
+                time += instruction.getTime();
+                distance += instruction.getDistance();
+                isFirstInstructionOfLeg = false;
+                if (instruction.getSign() == Instruction.REACHED_VIA || instruction.getSign() == Instruction.FINISH) {
+                    putLegInformation(legJson, path, i, time, distance);
+                    isFirstInstructionOfLeg = true;
+
+                    if (instruction.getSign() == Instruction.REACHED_VIA) {
+                        // Create new leg and steps after a via points
+                        legJson = legsJson.addObject();
+                        steps = legJson.putArray("steps");
+                    }
+                }
             }
 
             pathJson.put("weight_name", "routability");
@@ -99,7 +103,22 @@ public class MapboxResponseConverter {
         return json;
     }
 
-    private static ObjectNode putInstruction(InstructionList instructions, int index, Locale locale, TranslationMap translationMap, ObjectNode instructionJson) {
+    private static void putLegInformation(ObjectNode legJson, PathWrapper path, int i, long time, double distance) {
+        // TODO: Improve path descriptions, so that every path has a description, not just alternative routes
+        String summary;
+        if (!path.getDescription().isEmpty())
+            summary = String.join(",", path.getDescription());
+        else
+            summary = "GraphHopper Route " + i;
+        legJson.put("summary", summary);
+
+        // TODO there is no weight per instruction, let's use time
+        legJson.put("weight", convertToSeconds(time));
+        legJson.put("duration", convertToSeconds(time));
+        legJson.put("distance", Helper.round(distance, 1));
+    }
+
+    private static ObjectNode putInstruction(InstructionList instructions, int index, Locale locale, TranslationMap translationMap, ObjectNode instructionJson, boolean isFirstInstructionOfLeg) {
         Instruction instruction = instructions.get(index);
         ArrayNode intersections = instructionJson.putArray("intersections");
         ObjectNode intersection = intersections.addObject();
@@ -116,7 +135,7 @@ public class MapboxResponseConverter {
         // TODO: how about other modes?
         instructionJson.put("mode", "driving");
 
-        putManeuver(instruction, instructionJson, index, locale, translationMap);
+        putManeuver(instruction, instructionJson, locale, translationMap, isFirstInstructionOfLeg);
 
         // TODO distance = weight, is weight even important?
         double distance = Helper.round(instruction.getDistance(), 1);
@@ -200,7 +219,7 @@ public class MapboxResponseConverter {
         component.put("text", bannerInstructionName);
         component.put("type", "text");
 
-        primary.put("type", getTurnType(nextInstruction, index + 1));
+        primary.put("type", getTurnType(nextInstruction, false));
         String modifier = getModifier(nextInstruction);
         if (modifier != null)
             primary.put("modifier", modifier);
@@ -210,7 +229,7 @@ public class MapboxResponseConverter {
         bannerInstruction.putNull("secondary");
     }
 
-    private static void putManeuver(Instruction instruction, ObjectNode instructionJson, int index, Locale locale, TranslationMap translationMap) {
+    private static void putManeuver(Instruction instruction, ObjectNode instructionJson, Locale locale, TranslationMap translationMap, boolean isFirstInstructionOfLeg) {
         ObjectNode maneuver = instructionJson.putObject("maneuver");
         maneuver.put("bearing_after", 0);
         maneuver.put("bearing_before", 0);
@@ -222,7 +241,7 @@ public class MapboxResponseConverter {
         if (modifier != null)
             maneuver.put("modifier", modifier);
 
-        maneuver.put("type", getTurnType(instruction, index));
+        maneuver.put("type", getTurnType(instruction, isFirstInstructionOfLeg));
         // exit number
         if (instruction instanceof RoundaboutInstruction)
             maneuver.put("exit", ((RoundaboutInstruction) instruction).getExitNumber());
@@ -240,8 +259,8 @@ public class MapboxResponseConverter {
      *
      * You can find all at: https://www.mapbox.com/api-documentation/#maneuver-types
      */
-    private static String getTurnType(Instruction instruction, int index) {
-        if (index == 0) {
+    private static String getTurnType(Instruction instruction, boolean isFirstInstructionOfLeg) {
+        if (isFirstInstructionOfLeg) {
             return "depart";
         } else {
             switch (instruction.getSign()) {

--- a/mapbox/src/main/java/com/graphhopper/navigation/mapbox/MapboxResponseConverter.java
+++ b/mapbox/src/main/java/com/graphhopper/navigation/mapbox/MapboxResponseConverter.java
@@ -72,6 +72,8 @@ public class MapboxResponseConverter {
                 if (instruction.getSign() == Instruction.REACHED_VIA || instruction.getSign() == Instruction.FINISH) {
                     putLegInformation(legJson, path, i, time, distance);
                     isFirstInstructionOfLeg = true;
+                    time = 0;
+                    distance = 0;
 
                     if (instruction.getSign() == Instruction.REACHED_VIA) {
                         // Create new leg and steps after a via points

--- a/mapbox/src/test/java/com/graphhopper/navigation/mapbox/MapboxResponseConverterTest.java
+++ b/mapbox/src/test/java/com/graphhopper/navigation/mapbox/MapboxResponseConverterTest.java
@@ -143,6 +143,7 @@ public class MapboxResponseConverterTest {
 
         ObjectNode json = MapboxResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH);
 
+        //Check that all waypoints are there and in the right order
         JsonNode waypointsJson = json.get("waypoints");
         assertEquals(4, waypointsJson.size());
 
@@ -157,6 +158,21 @@ public class MapboxResponseConverterTest {
 
         waypointLoc = waypointsJson.get(3).get("location");
         assertEquals(1.527218, waypointLoc.get(0).asDouble(), .00001);
+
+        //Check that there are 3 legs
+        JsonNode legs = json.get("routes").get(0).get("legs");
+        assertEquals(3, legs.size());
+
+        for (int i = 0; i < 3; i++) {
+            JsonNode leg = legs.get(i);
+            JsonNode steps = leg.get("steps");
+            JsonNode step = steps.get(0);
+            JsonNode maneuver = step.get("maneuver");
+            assertEquals("depart", maneuver.get("type").asText());
+
+            maneuver = steps.get(steps.size() - 1).get("maneuver");
+            assertEquals("arrive", maneuver.get("type").asText());
+        }
     }
 
     @Test

--- a/mapbox/src/test/java/com/graphhopper/navigation/mapbox/MapboxResponseConverterTest.java
+++ b/mapbox/src/test/java/com/graphhopper/navigation/mapbox/MapboxResponseConverterTest.java
@@ -160,11 +160,19 @@ public class MapboxResponseConverterTest {
         assertEquals(1.527218, waypointLoc.get(0).asDouble(), .00001);
 
         //Check that there are 3 legs
-        JsonNode legs = json.get("routes").get(0).get("legs");
+        JsonNode route = json.get("routes").get(0);
+        JsonNode legs = route.get("legs");
         assertEquals(3, legs.size());
+
+        double duration = 0;
+        double distance = 0;
 
         for (int i = 0; i < 3; i++) {
             JsonNode leg = legs.get(i);
+
+            duration += leg.get("duration").asDouble();
+            distance += leg.get("distance").asDouble();
+
             JsonNode steps = leg.get("steps");
             JsonNode step = steps.get(0);
             JsonNode maneuver = step.get("maneuver");
@@ -173,6 +181,10 @@ public class MapboxResponseConverterTest {
             maneuver = steps.get(steps.size() - 1).get("maneuver");
             assertEquals("arrive", maneuver.get("type").asText());
         }
+
+        // Check if the duration and distance of the legs sum up to the overall route distance and duration
+        assertEquals(route.get("duration").asDouble(), duration, 1);
+        assertEquals(route.get("distance").asDouble(), distance, 1);
     }
 
     @Test


### PR DESCRIPTION
This PR allows to convert requests with multiple waypoints to be converted. I tested the change with the Mapbox SDK and everything seems to work as expected.

Sometimes the Mapbox SDK seems to behave a bit odd, when using multiple waypoints (like skipping one). But the same happens with the Mapbox API, so this is not an issue of this PR.