### PR TITLE
Add alternative Routes to Navigation Endpoint

### DIFF
--- a/mapbox/src/main/java/com/graphhopper/navigation/mapbox/MapboxResource.java
+++ b/mapbox/src/main/java/com/graphhopper/navigation/mapbox/MapboxResource.java
@@ -20,6 +20,7 @@ package com.graphhopper.navigation.mapbox;
 import com.graphhopper.GHRequest;
 import com.graphhopper.GHResponse;
 import com.graphhopper.GraphHopperAPI;
+import com.graphhopper.util.Helper;
 import com.graphhopper.util.Parameters;
 import com.graphhopper.util.StopWatch;
 import com.graphhopper.util.TranslationMap;
@@ -118,6 +119,34 @@ public class MapboxResource {
 
         StopWatch sw = new StopWatch().start();
 
+        GHResponse ghResponse = calcRoute(favoredHeadings, requestPoints, vehicleStr, weighting, localeStr, enableInstructions, minPathPrecision);
+
+        if (!ghResponse.hasErrors() && favoredHeadings.size() > 0) {
+            GHResponse noHeadingResponse = calcRoute(Collections.EMPTY_LIST, requestPoints, vehicleStr, weighting, localeStr, enableInstructions, minPathPrecision);
+            if (ghResponse.getBest().getDistance() != noHeadingResponse.getBest().getDistance()) {
+                ghResponse.getAll().add(noHeadingResponse.getBest());
+            }
+        }
+
+        float took = sw.stop().getSeconds();
+        String infoStr = httpReq.getRemoteAddr() + " " + httpReq.getLocale() + " " + httpReq.getHeader("User-Agent");
+        String logStr = httpReq.getQueryString() + " " + infoStr + " " + requestPoints + ", took:"
+                + took + ", " + weighting + ", " + vehicleStr;
+
+        if (ghResponse.hasErrors()) {
+            logger.error(logStr + ", errors:" + ghResponse.getErrors());
+            // Mapbox specifies 422 return type for input errors
+            return Response.status(422).entity(MapboxResponseConverter.convertFromGHResponseError(ghResponse)).
+                    header("X-GH-Took", "" + Math.round(took * 1000)).
+                    build();
+        } else {
+            return Response.ok(MapboxResponseConverter.convertFromGHResponse(ghResponse, translationMap, mapboxResponseConverterTranslationMap, Helper.getLocale(localeStr))).
+                    header("X-GH-Took", "" + Math.round(took * 1000)).
+                    build();
+        }
+    }
+
+    private GHResponse calcRoute(List<Double> favoredHeadings, List<GHPoint> requestPoints, String vehicleStr, String weighting, String localeStr, boolean enableInstructions, double minPathPrecision) {
         GHRequest request;
         if (favoredHeadings.size() > 0) {
             request = new GHRequest(requestPoints, favoredHeadings);
@@ -135,24 +164,7 @@ public class MapboxResource {
                 put(Parameters.CH.DISABLE, true).
                 put(Parameters.Routing.PASS_THROUGH, false);
 
-        GHResponse ghResponse = graphHopper.route(request);
-
-        float took = sw.stop().getSeconds();
-        String infoStr = httpReq.getRemoteAddr() + " " + httpReq.getLocale() + " " + httpReq.getHeader("User-Agent");
-        String logStr = httpReq.getQueryString() + " " + infoStr + " " + requestPoints + ", took:"
-                + took + ", " + weighting + ", " + vehicleStr;
-
-        if (ghResponse.hasErrors()) {
-            logger.error(logStr + ", errors:" + ghResponse.getErrors());
-            // Mapbox specifies 422 return type for input errors
-            return Response.status(422).entity(MapboxResponseConverter.convertFromGHResponseError(ghResponse)).
-                    header("X-GH-Took", "" + Math.round(took * 1000)).
-                    build();
-        } else {
-            return Response.ok(MapboxResponseConverter.convertFromGHResponse(ghResponse, translationMap, mapboxResponseConverterTranslationMap, request.getLocale())).
-                    header("X-GH-Took", "" + Math.round(took * 1000)).
-                    build();
-        }
+        return graphHopper.route(request);
     }
 
     /**

--- a/mapbox/src/main/java/com/graphhopper/navigation/mapbox/MapboxResource.java
+++ b/mapbox/src/main/java/com/graphhopper/navigation/mapbox/MapboxResource.java
@@ -121,7 +121,8 @@ public class MapboxResource {
 
         GHResponse ghResponse = calcRoute(favoredHeadings, requestPoints, vehicleStr, weighting, localeStr, enableInstructions, minPathPrecision);
 
-        if (!ghResponse.hasErrors() && favoredHeadings.size() > 0) {
+        // Only do this, when there are more than 2 points, otherwise we use alternative routes
+        if (!ghResponse.hasErrors() && favoredHeadings.size() > 2) {
             GHResponse noHeadingResponse = calcRoute(Collections.EMPTY_LIST, requestPoints, vehicleStr, weighting, localeStr, enableInstructions, minPathPrecision);
             if (ghResponse.getBest().getDistance() != noHeadingResponse.getBest().getDistance()) {
                 ghResponse.getAll().add(noHeadingResponse.getBest());
@@ -163,6 +164,9 @@ public class MapboxResource {
                 put(WAY_POINT_MAX_DISTANCE, minPathPrecision).
                 put(Parameters.CH.DISABLE, true).
                 put(Parameters.Routing.PASS_THROUGH, false);
+
+        if (requestPoints.size() == 2)
+            request.setAlgorithm(Parameters.Algorithms.ALT_ROUTE);
 
         return graphHopper.route(request);
     }

--- a/mapbox/src/main/java/com/graphhopper/navigation/mapbox/MapboxResource.java
+++ b/mapbox/src/main/java/com/graphhopper/navigation/mapbox/MapboxResource.java
@@ -122,7 +122,7 @@ public class MapboxResource {
         GHResponse ghResponse = calcRoute(favoredHeadings, requestPoints, vehicleStr, weighting, localeStr, enableInstructions, minPathPrecision);
 
         // Only do this, when there are more than 2 points, otherwise we use alternative routes
-        if (!ghResponse.hasErrors() && favoredHeadings.size() > 2) {
+        if (!ghResponse.hasErrors() && favoredHeadings.size() > 0) {
             GHResponse noHeadingResponse = calcRoute(Collections.EMPTY_LIST, requestPoints, vehicleStr, weighting, localeStr, enableInstructions, minPathPrecision);
             if (ghResponse.getBest().getDistance() != noHeadingResponse.getBest().getDistance()) {
                 ghResponse.getAll().add(noHeadingResponse.getBest());
@@ -164,9 +164,6 @@ public class MapboxResource {
                 put(WAY_POINT_MAX_DISTANCE, minPathPrecision).
                 put(Parameters.CH.DISABLE, true).
                 put(Parameters.Routing.PASS_THROUGH, false);
-
-        if (requestPoints.size() == 2)
-            request.setAlgorithm(Parameters.Algorithms.ALT_ROUTE);
 
         return graphHopper.route(request);
     }

--- a/mapbox/src/test/java/com/graphhopper/navigation/mapbox/MapboxResponseConverterTest.java
+++ b/mapbox/src/test/java/com/graphhopper/navigation/mapbox/MapboxResponseConverterTest.java
@@ -8,6 +8,7 @@ import com.graphhopper.GraphHopper;
 import com.graphhopper.reader.osm.GraphHopperOSM;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.util.Helper;
+import com.graphhopper.util.Parameters;
 import com.graphhopper.util.TranslationMap;
 import com.graphhopper.util.shapes.GHPoint;
 import org.junit.*;
@@ -162,6 +163,23 @@ public class MapboxResponseConverterTest {
 
         voiceInstruction = voiceInstructions.get(3);
         assertEquals("keep right", voiceInstruction.get("announcement").asText());
+    }
+
+    @Test
+    public void alternativeRoutesTest() {
+
+        GHResponse rsp = hopper.route(new GHRequest(42.554851, 1.536198, 42.510071, 1.548128).
+                setVehicle(vehicle).setAlgorithm(Parameters.Algorithms.ALT_ROUTE));
+
+        assertEquals(2, rsp.getAll().size());
+
+        ObjectNode json = MapboxResponseConverter.convertFromGHResponse(rsp, trMap, mtrMap, Locale.ENGLISH);
+
+        JsonNode routes = json.get("routes");
+        assertEquals(2, routes.size());
+
+        assertEquals("GraphHopper Route 0", routes.get(0).get("legs").get(0).get("summary").asText());
+        assertEquals("Avinguda Sant Antoni, CG-3", routes.get(1).get("legs").get(0).get("summary").asText());
     }
 
     @Test


### PR DESCRIPTION
This PR enables alternative routes for route requests.

Currently alternative routes in GraphHopper core are limited to 2 points, so when passing more than 2 points we check if there is a heading, if there is a heading, we remove it and see if the calculated route is different, if yes, this will be added as alternative route.