### PR TITLE
Add next turn instruction in voice instructions and banner instructions

### DIFF
--- a/mapbox/src/main/resources/com/graphhopper/navigation/mapbox/de_DE.txt
+++ b/mapbox/src/main/resources/com/graphhopper/navigation/mapbox/de_DE.txt
@@ -2,3 +2,4 @@ in_km_singular=In 1 Kilometer
 in_km=In %1$s Kilometern
 in_m=In %1$s Metern
 for_km=für %1$s Kilometer
+then=dann

--- a/mapbox/src/main/resources/com/graphhopper/navigation/mapbox/en_US.txt
+++ b/mapbox/src/main/resources/com/graphhopper/navigation/mapbox/en_US.txt
@@ -2,3 +2,4 @@ in_km_singular=In 1 kilometer
 in_km=In %1$s kilometers
 in_m=In %1$s meters
 for_km=for %1$s kilometer
+then=then

--- a/mapbox/src/test/java/com/graphhopper/navigation/mapbox/MapboxResponseConverterTest.java
+++ b/mapbox/src/test/java/com/graphhopper/navigation/mapbox/MapboxResponseConverterTest.java
@@ -100,7 +100,7 @@ public class MapboxResponseConverterTest {
         assertEquals(1, voiceInstructions.size());
         JsonNode voiceInstruction = voiceInstructions.get(0);
         assertTrue(voiceInstruction.get("distanceAlongGeometry").asDouble() <= instructionDistance);
-        assertEquals("turn sharp left onto la Callisa", voiceInstruction.get("announcement").asText());
+        assertEquals("turn sharp left onto la Callisa, then keep left", voiceInstruction.get("announcement").asText());
 
         JsonNode bannerInstructions = step.get("bannerInstructions");
         assertEquals(1, bannerInstructions.size());
@@ -149,7 +149,7 @@ public class MapboxResponseConverterTest {
         assertEquals(2, voiceInstructions.size());
         JsonNode voiceInstruction = voiceInstructions.get(0);
         assertEquals(200, voiceInstruction.get("distanceAlongGeometry").asDouble(), 1);
-        assertEquals("In 200 meters At roundabout, take exit 2 onto CS-340", voiceInstruction.get("announcement").asText());
+        assertEquals("In 200 meters At roundabout, take exit 2 onto CS-340, then At roundabout, take exit 2 onto CG-3", voiceInstruction.get("announcement").asText());
 
         // Step 15 is over 3km long
         step = steps.get(15);


### PR DESCRIPTION
Fixes #13.

This PR make the next turn more visible for the user.

For voice instructions, if the next turn is close to the current turn, we add a `, then turn X`. For banner instructions we also add the next turn as `sub` component ([related to this issue](wYonyRi2hNgJVH2qgs81)).

- We have to experiemnt a bit more with the distance of the next turn at which we should merge the then instruction. Currently this is 100m which seems to work fine in my tests so far.

We should think about how we handle banner instructions. There are a couple of things we can control:

- When the next turn should be shown (like 200m before the turn)
- If we should show the next turn instruction at all. (The SDK seems to sometimes add the next turn instruction even if it's not specified in the server response).