### PR TITLE
Add points

### DIFF
--- a/src/main/java/com/graphhopper/navigation/NavigateResponseConverter.java
+++ b/src/main/java/com/graphhopper/navigation/NavigateResponseConverter.java
@@ -132,7 +132,18 @@ public class NavigateResponseConverter {
         ObjectNode intersection = intersections.addObject();
         intersection.putArray("entry");
         intersection.putArray("bearings");
-        PointList pointList = instruction.getPoints();
+        //Make pointList mutable
+        PointList pointList = instruction.getPoints().clone(false);
+
+        if (index + 2 < instructions.size()) {
+            // Add the first point of the next instruction
+            PointList nextPoints = instructions.get(index + 1).getPoints();
+            pointList.add(nextPoints.getLat(0), nextPoints.getLon(0), nextPoints.getEle(0));
+        } else if (pointList.size() == 1) {
+            // Duplicate the last point in the arrive instruction, if the size is 1
+            pointList.add(pointList.getLat(0), pointList.getLon(0), pointList.getEle(0));
+        }
+
         putLocation(pointList.getLat(0), pointList.getLon(0), intersection);
 
         instructionJson.put("driving_side", "right");


### PR DESCRIPTION
We have seen an issue in the SDK that sometimes the orientation of the location marker turns in the wrong direction at intersections.

The solution seems to add the first point of the next instruction as last point of the current instruction. For the final instruction, the point is simply duplicated.

This also seems to fix the issue we have seen in the simulator, see https://github.com/graphhopper/graphhopper-navigation-android/issues/1