### PR TITLE
Allow using GraphHopper Profiles as well

### DIFF
--- a/src/main/java/com/graphhopper/navigation/NavigateResource.java
+++ b/src/main/java/com/graphhopper/navigation/NavigateResource.java
@@ -214,7 +214,7 @@ public class NavigateResource {
             case "cycling":
                 return "bike";
             default:
-                throw new IllegalArgumentException("Not supported profile: " + profile);
+                return profile;
         }
     }
 


### PR DESCRIPTION
This PR allows to fall back to the GraphHopper profile if the requested profile doesn't match any of the given navigate profiles.