### PR TITLE
Fix continue instruction translation

### DIFF
--- a/src/main/java/com/graphhopper/navigation/DistanceConfig.java
+++ b/src/main/java/com/graphhopper/navigation/DistanceConfig.java
@@ -11,28 +11,22 @@ import java.util.Locale;
 import static com.graphhopper.navigation.DistanceUtils.UnitTranslationKey.*;
 
 public class DistanceConfig {
-    final DistanceUtils.Unit unit;
     final List<VoiceInstructionConfig> voiceInstructions;
-    final TranslationMap translationMap;
-    final Locale locale;
 
-    public DistanceConfig(DistanceUtils.Unit unit, TranslationMap translationMap, Locale locale) {
-        this.unit = unit;
-        this.translationMap = translationMap;
-        this.locale = locale;
+    public DistanceConfig(DistanceUtils.Unit unit,  TranslationMap translationMap, TranslationMap navigateResponseConverterTranslationMap, Locale locale) {
         if (unit == DistanceUtils.Unit.METRIC) {
             voiceInstructions = Arrays.asList(
-                    new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.metric, translationMap, locale, 4250, 250, unit),
-                    new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_PLURAL.metric, translationMap, locale, 2000, 2),
-                    new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_SINGULAR.metric, translationMap, locale, 1000, 1),
-                    new ConditionalDistanceVoiceInstructionConfig(IN_LOWER_DISTANCE_PLURAL.metric, translationMap, locale, new int[]{400, 200}, new int[]{400, 200})
+                    new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.metric, translationMap, navigateResponseConverterTranslationMap, locale, 4250, 250, unit),
+                    new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_PLURAL.metric, navigateResponseConverterTranslationMap, locale, 2000, 2),
+                    new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_SINGULAR.metric, navigateResponseConverterTranslationMap, locale, 1000, 1),
+                    new ConditionalDistanceVoiceInstructionConfig(IN_LOWER_DISTANCE_PLURAL.metric, navigateResponseConverterTranslationMap, locale, new int[]{400, 200}, new int[]{400, 200})
             );
         } else {
             voiceInstructions = Arrays.asList(
-                    new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.metric, translationMap, locale, 4250, 250, unit),
-                    new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_PLURAL.imperial, translationMap, locale, 3220, 2),
-                    new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_SINGULAR.imperial, translationMap, locale, 1610, 1),
-                    new ConditionalDistanceVoiceInstructionConfig(IN_LOWER_DISTANCE_PLURAL.imperial, translationMap, locale, new int[]{400, 200}, new int[]{1300, 600})
+                    new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.metric, translationMap, navigateResponseConverterTranslationMap, locale, 4250, 250, unit),
+                    new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_PLURAL.imperial, navigateResponseConverterTranslationMap, locale, 3220, 2),
+                    new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_SINGULAR.imperial, navigateResponseConverterTranslationMap, locale, 1610, 1),
+                    new ConditionalDistanceVoiceInstructionConfig(IN_LOWER_DISTANCE_PLURAL.imperial, navigateResponseConverterTranslationMap, locale, new int[]{400, 200}, new int[]{1300, 600})
             );
         }
 

--- a/src/main/java/com/graphhopper/navigation/NavigateResource.java
+++ b/src/main/java/com/graphhopper/navigation/NavigateResource.java
@@ -145,7 +145,7 @@ public class NavigateResource {
         String logStr = httpReq.getQueryString() + " " + infoStr + " " + requestPoints + ", took:"
                 + took + ", " + weighting + ", " + vehicleStr;
         Locale locale = Helper.getLocale(localeStr);
-        DistanceConfig config = new DistanceConfig(unit, navigateResponseConverterTranslationMap, locale);
+        DistanceConfig config = new DistanceConfig(unit, translationMap, navigateResponseConverterTranslationMap, locale);
 
         if (ghResponse.hasErrors()) {
             logger.error(logStr + ", errors:" + ghResponse.getErrors());

--- a/src/main/java/com/graphhopper/navigation/VoiceInstructionConfig.java
+++ b/src/main/java/com/graphhopper/navigation/VoiceInstructionConfig.java
@@ -1,5 +1,6 @@
 package com.graphhopper.navigation;
 
+import com.graphhopper.util.Helper;
 import com.graphhopper.util.TranslationMap;
 
 import java.util.Locale;
@@ -9,12 +10,12 @@ import static com.graphhopper.navigation.DistanceUtils.meterToMiles;
 
 abstract class VoiceInstructionConfig {
     protected final String key; // TranslationMap key
-    protected final TranslationMap translationMap;
+    protected final TranslationMap navigateResponseConverterTranslationMap;
     protected final Locale locale;
 
-    public VoiceInstructionConfig(String key, TranslationMap translationMap, Locale locale) {
+    public VoiceInstructionConfig(String key, TranslationMap navigateResponseConverterTranslationMap, Locale locale) {
         this.key = key;
-        this.translationMap = translationMap;
+        this.navigateResponseConverterTranslationMap = navigateResponseConverterTranslationMap;
         this.locale = locale;
     }
 
@@ -38,8 +39,8 @@ class ConditionalDistanceVoiceInstructionConfig extends VoiceInstructionConfig {
     private final int[] distanceAlongGeometry; // distances in meter in which the instruction should be spoken
     private final int[] distanceVoiceValue; // distances in required unit. f.e: 1km, 300m or 2mi
 
-    public ConditionalDistanceVoiceInstructionConfig(String key, TranslationMap translationMap, Locale locale, int[] distanceAlongGeometry, int[] distanceVoiceValue) {
-        super(key, translationMap, locale);
+    public ConditionalDistanceVoiceInstructionConfig(String key, TranslationMap navigateResponseConverterTranslationMap, Locale locale, int[] distanceAlongGeometry, int[] distanceVoiceValue) {
+        super(key, navigateResponseConverterTranslationMap, locale);
         this.distanceAlongGeometry = distanceAlongGeometry;
         this.distanceVoiceValue = distanceVoiceValue;
         if (distanceAlongGeometry.length != distanceVoiceValue.length) {
@@ -62,7 +63,7 @@ class ConditionalDistanceVoiceInstructionConfig extends VoiceInstructionConfig {
         if (instructionIndex < 0) {
             return null;
         }
-        String totalDescription = translationMap.getWithFallBack(locale).tr(key, distanceVoiceValue[instructionIndex]) + " " + turnDescription + thenVoiceInstruction;
+        String totalDescription = navigateResponseConverterTranslationMap.getWithFallBack(locale).tr(key, distanceVoiceValue[instructionIndex]) + " " + turnDescription + thenVoiceInstruction;
         int spokenDistance = distanceAlongGeometry[instructionIndex];
         return new VoiceInstructionValue(spokenDistance, totalDescription);
     }
@@ -72,8 +73,8 @@ class FixedDistanceVoiceInstructionConfig extends VoiceInstructionConfig {
     private final int distanceAlongGeometry; // distance in meter in which the instruction should be spoken
     private final int distanceVoiceValue; // distance in required unit. f.e: 1km, 300m or 2mi
 
-    public FixedDistanceVoiceInstructionConfig(String key, TranslationMap translationMap, Locale locale, int distanceAlongGeometry, int distanceVoiceValue) {
-        super(key, translationMap, locale);
+    public FixedDistanceVoiceInstructionConfig(String key, TranslationMap navigateResponseConverterTranslationMap, Locale locale, int distanceAlongGeometry, int distanceVoiceValue) {
+        super(key, navigateResponseConverterTranslationMap, locale);
         this.distanceAlongGeometry = distanceAlongGeometry;
         this.distanceVoiceValue = distanceVoiceValue;
     }
@@ -81,7 +82,7 @@ class FixedDistanceVoiceInstructionConfig extends VoiceInstructionConfig {
     @Override
     public VoiceInstructionValue getConfigForDistance(double distance, String turnDescription, String thenVoiceInstruction) {
         if (distance >= distanceAlongGeometry) {
-            String totalDescription = translationMap.getWithFallBack(locale).tr(key, distanceVoiceValue) + " " + turnDescription;
+            String totalDescription = navigateResponseConverterTranslationMap.getWithFallBack(locale).tr(key, distanceVoiceValue) + " " + turnDescription;
             return new VoiceInstructionValue(distanceAlongGeometry, totalDescription);
         }
         return null;
@@ -94,12 +95,14 @@ class InitialVoiceInstructionConfig extends VoiceInstructionConfig {
     private final int distanceDelay; // delay distance in meter
     private final int distanceForInitialStayInstruction; // min distance in meter for initial instruction
     private final DistanceUtils.Unit unit;
+    private final TranslationMap translationMap;
 
-    public InitialVoiceInstructionConfig(String key, TranslationMap translationMap, Locale locale, int distanceForInitialStayInstruction, int distanceDelay, DistanceUtils.Unit unit) {
-        super(key, translationMap, locale);
+    public InitialVoiceInstructionConfig(String key, TranslationMap translationMap, TranslationMap navigateResponseConverterTranslationMap, Locale locale, int distanceForInitialStayInstruction, int distanceDelay, DistanceUtils.Unit unit) {
+        super(key, navigateResponseConverterTranslationMap, locale);
         this.distanceForInitialStayInstruction = distanceForInitialStayInstruction;
         this.distanceDelay = distanceDelay;
         this.unit = unit;
+        this.translationMap = translationMap;
     }
 
     private int distanceAlongGeometry(double distanceMeter) {
@@ -126,7 +129,8 @@ class InitialVoiceInstructionConfig extends VoiceInstructionConfig {
         if (distance > distanceForInitialStayInstruction) {
             int spokenDistance = distanceAlongGeometry(distance);
             int distanceVoiceValue = distanceVoiceValue(distance);
-            String continueDescription = translationMap.getWithFallBack(locale).tr("continue", translationMap.getWithFallBack(locale).tr(key, distanceVoiceValue));
+            String continueDescription = translationMap.getWithFallBack(locale).tr("continue") + " " + navigateResponseConverterTranslationMap.getWithFallBack(locale).tr(key, distanceVoiceValue);
+            continueDescription = Helper.firstBig(continueDescription);
             return new VoiceInstructionValue(spokenDistance, continueDescription);
         }
         return null;

--- a/src/main/java/com/graphhopper/navigation/VoiceInstructionConfig.java
+++ b/src/main/java/com/graphhopper/navigation/VoiceInstructionConfig.java
@@ -126,7 +126,7 @@ class InitialVoiceInstructionConfig extends VoiceInstructionConfig {
         if (distance > distanceForInitialStayInstruction) {
             int spokenDistance = distanceAlongGeometry(distance);
             int distanceVoiceValue = distanceVoiceValue(distance);
-            String continueDescription = translationMap.getWithFallBack(locale).tr("continue") + " " + translationMap.getWithFallBack(locale).tr(key, distanceVoiceValue);
+            String continueDescription = translationMap.getWithFallBack(locale).tr("continue", translationMap.getWithFallBack(locale).tr(key, distanceVoiceValue));
             return new VoiceInstructionValue(spokenDistance, continueDescription);
         }
         return null;

--- a/src/main/resources/com/graphhopper/navigation/de_DE.txt
+++ b/src/main/resources/com/graphhopper/navigation/de_DE.txt
@@ -7,3 +7,4 @@ in_mi_singular=In 1 Meile
 in_mi=In %1$s Meilen
 in_ft=In %1$s Fuß
 for_mi=für %1$s Meilen
+continue=Dem Straßenverlauf %1$s folgen

--- a/src/main/resources/com/graphhopper/navigation/de_DE.txt
+++ b/src/main/resources/com/graphhopper/navigation/de_DE.txt
@@ -7,4 +7,3 @@ in_mi_singular=In 1 Meile
 in_mi=In %1$s Meilen
 in_ft=In %1$s Fuß
 for_mi=für %1$s Meilen
-continue=Dem Straßenverlauf %1$s folgen

--- a/src/main/resources/com/graphhopper/navigation/en_US.txt
+++ b/src/main/resources/com/graphhopper/navigation/en_US.txt
@@ -7,4 +7,3 @@ in_mi_singular=In 1 mile
 in_mi=In %1$s miles
 in_ft=In %1$s feet
 for_mi=for %1$s miles
-continue=Continue %1$s

--- a/src/main/resources/com/graphhopper/navigation/en_US.txt
+++ b/src/main/resources/com/graphhopper/navigation/en_US.txt
@@ -1,9 +1,10 @@
 in_km_singular=In 1 kilometer
 in_km=In %1$s kilometers
 in_m=In %1$s meters
-for_km=for %1$s kilometer
+for_km=for %1$s kilometers
 then=then
 in_mi_singular=In 1 mile
 in_mi=In %1$s miles
 in_ft=In %1$s feet
 for_mi=for %1$s miles
+continue=Continue %1$s

--- a/src/test/java/com/graphhopper/navigation/NavigateResponseConverterTest.java
+++ b/src/test/java/com/graphhopper/navigation/NavigateResponseConverterTest.java
@@ -31,7 +31,7 @@ public class NavigateResponseConverterTest {
 
     private final TranslationMap trMap = new TranslationMap().doImport();
     private final TranslationMap mtrMap = new NavigateResponseConverterTranslationMap().doImport();
-    private final DistanceConfig distanceConfig = new DistanceConfig(DistanceUtils.Unit.METRIC, mtrMap, Locale.ENGLISH);
+    private final DistanceConfig distanceConfig = new DistanceConfig(DistanceUtils.Unit.METRIC, trMap, mtrMap, Locale.ENGLISH);
 
     @BeforeClass
     public static void beforeClass() {
@@ -172,7 +172,7 @@ public class NavigateResponseConverterTest {
         GHResponse rsp = hopper.route(new GHRequest(42.554851, 1.536198, 42.510071, 1.548128).
                 setVehicle(vehicle));
 
-        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, mtrMap, Locale.ENGLISH, new DistanceConfig(DistanceUtils.Unit.IMPERIAL, mtrMap, Locale.ENGLISH));
+        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, mtrMap, Locale.ENGLISH, new DistanceConfig(DistanceUtils.Unit.IMPERIAL, trMap, mtrMap, Locale.ENGLISH));
 
         JsonNode steps = json.get("routes").get(0).get("legs").get(0).get("steps");
 
@@ -232,7 +232,7 @@ public class NavigateResponseConverterTest {
         rsp = hopper.route(new GHRequest(42.554851, 1.536198, 42.510071, 1.548128).
                 setVehicle(vehicle).setLocale(Locale.GERMAN));
 
-        DistanceConfig distanceConfigGerman = new DistanceConfig(DistanceUtils.Unit.METRIC, mtrMap, Locale.GERMAN);
+        DistanceConfig distanceConfigGerman = new DistanceConfig(DistanceUtils.Unit.METRIC, trMap, mtrMap, Locale.GERMAN);
 
         json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, mtrMap, Locale.GERMAN, distanceConfigGerman);
 

--- a/src/test/java/com/graphhopper/navigation/VoiceInstructionConfigTest.java
+++ b/src/test/java/com/graphhopper/navigation/VoiceInstructionConfigTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertNull;
 
 public class VoiceInstructionConfigTest {
 
+    private final TranslationMap trMap = new TranslationMap().doImport();
     private final TranslationMap mtrMap = new NavigateResponseConverterTranslationMap().doImport();
     private final Locale locale = Locale.ENGLISH;
 
@@ -96,7 +97,7 @@ public class VoiceInstructionConfigTest {
 
     @Test
     public void initialVICMetricTest() {
-        InitialVoiceInstructionConfig configMetric = new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.metric, mtrMap, locale, 4250, 250, DistanceUtils.Unit.METRIC);
+        InitialVoiceInstructionConfig configMetric = new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.metric, trMap, mtrMap, locale, 4250, 250, DistanceUtils.Unit.METRIC);
 
         compareVoiceInstructionValues(
                 4000,
@@ -113,24 +114,24 @@ public class VoiceInstructionConfigTest {
 
     @Test
     public void germanInitialVICMetricTest() {
-        InitialVoiceInstructionConfig configMetric = new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.metric, mtrMap, Locale.GERMAN, 4250, 250, DistanceUtils.Unit.METRIC);
+        InitialVoiceInstructionConfig configMetric = new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.metric, trMap, mtrMap, Locale.GERMAN, 4250, 250, DistanceUtils.Unit.METRIC);
 
         compareVoiceInstructionValues(
                 4000,
-                "Dem Straßenverlauf für 4 Kilometer folgen",
+                "Dem Straßenverlauf folgen für 4 Kilometer",
                 configMetric.getConfigForDistance(5000, "abbiegen", " dann")
         );
 
         compareVoiceInstructionValues(
                 4000,
-                "Dem Straßenverlauf für 4 Kilometer folgen",
+                "Dem Straßenverlauf folgen für 4 Kilometer",
                 configMetric.getConfigForDistance(4500, "abbiegen", " dann")
         );
     }
 
     @Test
     public void initialVICImperialTest() {
-        InitialVoiceInstructionConfig configImperial = new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.imperial, mtrMap, locale, 4250, 250, DistanceUtils.Unit.IMPERIAL);
+        InitialVoiceInstructionConfig configImperial = new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.imperial, trMap, mtrMap, locale, 4250, 250, DistanceUtils.Unit.IMPERIAL);
 
         compareVoiceInstructionValues(
                 3219,

--- a/src/test/java/com/graphhopper/navigation/VoiceInstructionConfigTest.java
+++ b/src/test/java/com/graphhopper/navigation/VoiceInstructionConfigTest.java
@@ -24,31 +24,31 @@ public class VoiceInstructionConfigTest {
     public void conditionalDistanceVICShouldReturnFirstFittingMetricValues() {
         ConditionalDistanceVoiceInstructionConfig config = new ConditionalDistanceVoiceInstructionConfig(IN_LOWER_DISTANCE_PLURAL.metric, mtrMap, locale, new int[]{400, 200}, new int[]{400, 200});
 
-        compareVoiceInstrucationValues(
+        compareVoiceInstructionValues(
                 400,
                 "In 400 meters turn then",
                 config.getConfigForDistance(10010, "turn", " then")
         );
 
-        compareVoiceInstrucationValues(
+        compareVoiceInstructionValues(
                 400,
                 "In 400 meters turn then",
                 config.getConfigForDistance(450, "turn", " then")
         );
 
-        compareVoiceInstrucationValues(
+        compareVoiceInstructionValues(
                 400,
                 "In 400 meters turn then",
                 config.getConfigForDistance(400, "turn", " then")
         );
 
-        compareVoiceInstrucationValues(
+        compareVoiceInstructionValues(
                 200,
                 "In 200 meters turn then",
                 config.getConfigForDistance(399, "turn", " then")
         );
 
-        compareVoiceInstrucationValues(
+        compareVoiceInstructionValues(
                 200,
                 "In 200 meters turn then",
                 config.getConfigForDistance(200, "turn", " then")
@@ -61,31 +61,31 @@ public class VoiceInstructionConfigTest {
     public void conditionalDistanceVICShouldReturnFirstFittingImperialValues() {
         ConditionalDistanceVoiceInstructionConfig config = new ConditionalDistanceVoiceInstructionConfig(IN_LOWER_DISTANCE_PLURAL.imperial, mtrMap, locale, new int[]{400, 200}, new int[]{600, 500});
 
-        compareVoiceInstrucationValues(
+        compareVoiceInstructionValues(
                 400,
                 "In 600 feet turn then",
                 config.getConfigForDistance(10010, "turn", " then")
         );
 
-        compareVoiceInstrucationValues(
+        compareVoiceInstructionValues(
                 400,
                 "In 600 feet turn then",
                 config.getConfigForDistance(450, "turn", " then")
         );
 
-        compareVoiceInstrucationValues(
+        compareVoiceInstructionValues(
                 400,
                 "In 600 feet turn then",
                 config.getConfigForDistance(400, "turn", " then")
         );
 
-        compareVoiceInstrucationValues(
+        compareVoiceInstructionValues(
                 200,
                 "In 500 feet turn then",
                 config.getConfigForDistance(399, "turn", " then")
         );
 
-        compareVoiceInstrucationValues(
+        compareVoiceInstructionValues(
                 200,
                 "In 500 feet turn then",
                 config.getConfigForDistance(200, "turn", " then")
@@ -98,16 +98,33 @@ public class VoiceInstructionConfigTest {
     public void initialVICMetricTest() {
         InitialVoiceInstructionConfig configMetric = new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.metric, mtrMap, locale, 4250, 250, DistanceUtils.Unit.METRIC);
 
-        compareVoiceInstrucationValues(
+        compareVoiceInstructionValues(
                 4000,
-                "continue for 4 kilometer",
+                "Continue for 4 kilometers",
                 configMetric.getConfigForDistance(5000, "turn", " then")
         );
 
-        compareVoiceInstrucationValues(
+        compareVoiceInstructionValues(
                 4000,
-                "continue for 4 kilometer",
+                "Continue for 4 kilometers",
                 configMetric.getConfigForDistance(4500, "turn", " then")
+        );
+    }
+
+    @Test
+    public void germanInitialVICMetricTest() {
+        InitialVoiceInstructionConfig configMetric = new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.metric, mtrMap, Locale.GERMAN, 4250, 250, DistanceUtils.Unit.METRIC);
+
+        compareVoiceInstructionValues(
+                4000,
+                "Dem Straßenverlauf für 4 Kilometer folgen",
+                configMetric.getConfigForDistance(5000, "abbiegen", " dann")
+        );
+
+        compareVoiceInstructionValues(
+                4000,
+                "Dem Straßenverlauf für 4 Kilometer folgen",
+                configMetric.getConfigForDistance(4500, "abbiegen", " dann")
         );
     }
 
@@ -115,30 +132,30 @@ public class VoiceInstructionConfigTest {
     public void initialVICImperialTest() {
         InitialVoiceInstructionConfig configImperial = new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.imperial, mtrMap, locale, 4250, 250, DistanceUtils.Unit.IMPERIAL);
 
-        compareVoiceInstrucationValues(
+        compareVoiceInstructionValues(
                 3219,
-                "continue for 2 miles",
+                "Continue for 2 miles",
                 configImperial.getConfigForDistance(5000, "turn", " then")
         );
 
-        compareVoiceInstrucationValues(
+        compareVoiceInstructionValues(
                 3219,
-                "continue for 2 miles",
+                "Continue for 2 miles",
                 configImperial.getConfigForDistance(4500, "turn", " then")
         );
     }
 
     @Test
-    public void fixedDistancenitialVICMetricTest(){
+    public void fixedDistanceInitialVICMetricTest(){
         FixedDistanceVoiceInstructionConfig configMetric = new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_PLURAL.metric,  mtrMap, locale, 2000, 2);
 
-        compareVoiceInstrucationValues(
+        compareVoiceInstructionValues(
                 2000,
                 "In 2 kilometers turn",
                 configMetric.getConfigForDistance(2100, "turn", " then")
         );
 
-        compareVoiceInstrucationValues(
+        compareVoiceInstructionValues(
                 2000,
                 "In 2 kilometers turn",
                 configMetric.getConfigForDistance(2000, "turn", " then")
@@ -148,16 +165,35 @@ public class VoiceInstructionConfigTest {
     }
 
     @Test
-    public void fixedDistancenitialVICImperialTest(){
+    public void germanFixedDistanceInitialVICMetricTest(){
+        FixedDistanceVoiceInstructionConfig configMetric = new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_PLURAL.metric,  mtrMap, Locale.GERMAN, 2000, 2);
+
+        compareVoiceInstructionValues(
+                2000,
+                "In 2 Kilometern abbiegen",
+                configMetric.getConfigForDistance(2100, "abbiegen", " dann")
+        );
+
+        compareVoiceInstructionValues(
+                2000,
+                "In 2 Kilometern abbiegen",
+                configMetric.getConfigForDistance(2000, "abbiegen", " dann")
+        );
+
+        assertNull( configMetric.getConfigForDistance(1999, "abbiegen", " dann"));
+    }
+
+    @Test
+    public void fixedDistanceInitialVICImperialTest(){
         FixedDistanceVoiceInstructionConfig configImperial = new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_PLURAL.imperial,  mtrMap, locale, 2000, 2);
 
-        compareVoiceInstrucationValues(
+        compareVoiceInstructionValues(
                 2000,
                 "In 2 miles turn",
                 configImperial.getConfigForDistance(2100, "turn", " then")
         );
 
-        compareVoiceInstrucationValues(
+        compareVoiceInstructionValues(
                 2000,
                 "In 2 miles turn",
                 configImperial.getConfigForDistance(2000, "turn", " then")
@@ -168,9 +204,9 @@ public class VoiceInstructionConfigTest {
 
     // Helper
 
-    private void compareVoiceInstrucationValues(int expectedSpokenDistance,
-                                                String expectedInstruction,
-                                                VoiceInstructionConfig.VoiceInstructionValue values) {
+    private void compareVoiceInstructionValues(int expectedSpokenDistance,
+                                               String expectedInstruction,
+                                               VoiceInstructionConfig.VoiceInstructionValue values) {
         assertEquals(expectedSpokenDistance, values.spokenDistance);
         assertEquals(expectedInstruction, values.turnDescription);
 


### PR DESCRIPTION
This PR fixes the issues with the continue instruction. Essentially the continue translation was missing. I think the issue was created because it's a bit confusing that we have two translationMaps  (see [here](https://github.com/graphhopper/graphhopper-navigation/issues?utf8=%E2%9C%93&q=translationmap) why we have two). 

In order to keep things simpler, I renamed the translationMaps to make it clearer which map is used where.